### PR TITLE
Changed: Bump commons-io:commons-io from 2.14.0 to 2.16.1

### DIFF
--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -26,7 +26,7 @@ android {
         // Bumping commons-io to a version higher than 2.5
         // will cause runtime exceptions on android < 8 due
         // to missing classes like java.nio.file.Path.
-        implementation "commons-io:commons-io:2.14.0"
+        implementation "commons-io:commons-io:2.16.1"
 
         implementation project(":terminal-view")
 


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.14.0 to 2.16.1.

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production update-type: version-update:semver-minor ...